### PR TITLE
Update dependencies, PixiJS to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -631,344 +631,344 @@
       }
     },
     "@pixi/accessibility": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.0.0-rc.3.tgz",
-      "integrity": "sha512-bpEupM2aDryuL9fjUMZZXs0hI/wrJu+DP59ae+8bHwkarMf3zUAhYOBorMsPZp4Sk/bUZMCPROwOZmLA/eaulg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-5.2.0.tgz",
+      "integrity": "sha512-IXnCy9YmzXl9/rMiXOzgFpP7onW0YNSnVQtFotonCEPd2azM/1p3Fy7wRTcpfOJm/JsMZRbnDeE/wB9Shg9/QQ==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/app": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.0.0-rc.3.tgz",
-      "integrity": "sha512-F2y642RThPORbWgYaxxRmp+mtHvfe1x/tM5WSv0TliZdn17SR4sxOHl0m7tOY35BeJN0sjK52kmguZ78IEX88A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/app/-/app-5.2.0.tgz",
+      "integrity": "sha512-5rhjAGPruzC3w6+knySIWk4II1Td8Fw0LVfg1K48BRXI1mLXCrZ3tJb6hdFuBPhgeIDz1tUwecJ4KfkJOWgqPg==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0"
       }
     },
     "@pixi/constants": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.0.0-rc.3.tgz",
-      "integrity": "sha512-PrMmpD6EcQpwx4UkPnYcPuk63oqW3LG2Y+gFMEWVO0nBrkVw0JY/5uwJ9wRz0AiQotFdpd/AmMC3mZl8y1l7jw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-5.2.0.tgz",
+      "integrity": "sha512-dXwzkKAvgpvOJmDBe9OQiE+HPp4uMIL/3ijHlyW0fgMqDPhtQtFcSUdSUAoFwb23Uaq56j1ejuEmly8LehJ0aQ=="
     },
     "@pixi/core": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.0.0-rc.3.tgz",
-      "integrity": "sha512-NuDKTmFkFEBYNKykT7BfpxmJdh5Cn3tmPVGvY/31LYvmo7XwYd6BEOOPL8RPJ/eaxPhPd6mRCeU9rmzPXQHA0g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-5.2.0.tgz",
+      "integrity": "sha512-h8UuVWHfbWVGEO3a4SQS4vk70LSFMUMPKCvVpPq/3LtIUgPVDZO3tGL4O2jFteKwbmWNIMDCpDmBMu3XlqPlNQ==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/runner": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/ticker": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/runner": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/ticker": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/display": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.0.0-rc.3.tgz",
-      "integrity": "sha512-lIcQeNH345FUTKcQDlsswLR1WBCwsUePqCXboB3YbDgH1O87kzNOMOM3UajKevZZY+dFUGPn+81EhazLDY/4dA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-5.2.0.tgz",
+      "integrity": "sha512-P+exW4aI7eyqhdmi0M3HmKJI+XzDYNYAiEsKMUyyONwbHYSVdjQF5hzPuvjUYotTNZ1stCWbf0457cNNSPLOzQ==",
       "requires": {
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/extract": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.0.0-rc.3.tgz",
-      "integrity": "sha512-6M5QV7PeQVzt3CjwZV+G9VU96s3PWBZVairrK6SHz1UF5l+2b7+fSiGksaZtPQGc+C9UAcITvtcSGGSJk+aHqw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-5.2.0.tgz",
+      "integrity": "sha512-LUDsB6z+gkSYcS8urr/JjdpLlf/z3mAjpMJDOZlcxCdPXdayVka2ruNnrWb4dvf9nV9Wg7T8v1IOFGOWpOHEdQ==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/filter-alpha": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.0.0-rc.3.tgz",
-      "integrity": "sha512-ZRQObRNd2oJqySoFP5URTIVjd9wdkaxmQ7ObaEhE6YeAmHctlB7GF7lcL0GM62OZDW+52HIAbunfRSYOIuIClA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-5.2.0.tgz",
+      "integrity": "sha512-Jv/eqSt6zmKr9oGoi4UgUWA/pgxhyBSGMtUWMHiwuqjkXWl4Em4bC5l0f5GUX85xqMCRLwvOeqOH+fBE9fKadw==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0"
       }
     },
     "@pixi/filter-blur": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.0.0-rc.3.tgz",
-      "integrity": "sha512-A9ujN4qVT97V+hasMnQKAdpJmtESplGaE8Y3EUf7NXtkd+HoOLQNEkCKvjlHhxvyg3+tCIwjNfoRqGJRI4vgDw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-5.2.0.tgz",
+      "integrity": "sha512-052qyY+X3HMEvHdorqXIbe+iODK0Sj3j8goZMvOL2qATW6bDBGRuwrO2rGZ70BnmGgrbIrXzDVemwo9uLWEZSA==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/settings": "^5.2.0"
       }
     },
     "@pixi/filter-color-matrix": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.0.0-rc.3.tgz",
-      "integrity": "sha512-hDGpK7AD4Shm9NS5wNNae9nLrzwM/xNV7Hq9vVeEXo67/xUd8rBEDY2gFNiFqKz3AzKB506PsOHIiKJN0gNbRw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-5.2.0.tgz",
+      "integrity": "sha512-wtPzz+2NtP9zDW9cFn/lTryf97/DYwka4yi9A+sMCteoATsrZJCKz0zzPV5AORKv0hpCfu9wGYTISItOC8mBKw==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0"
       }
     },
     "@pixi/filter-displacement": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.0.0-rc.3.tgz",
-      "integrity": "sha512-sqDboHuPKdBnZ1mx96XX5NSnVZqM4OgcGMniu8Wp05zOeVi9HRyUe3ul0Eu2SmrhVL4q0jRL26ehm8ITgEBXzA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-5.2.0.tgz",
+      "integrity": "sha512-489KUlNF4ZmHZPNmI2X77cE95sfbvvw5NASeNXKmbCn5xi2gPSxiPMTv4XUTdhdOKxNcy81NFEQicG21eW335Q==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/math": "^5.2.0"
       }
     },
     "@pixi/filter-fxaa": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.0.0-rc.3.tgz",
-      "integrity": "sha512-GcXbWTm7BwrWyKfMUTZ6Oikr0riPlXrgt7LU4DoOUqtNqvgi0rsr4Nlc6VqZ4ro4uzTH4/1embKfhyqdnTkPrQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-5.2.0.tgz",
+      "integrity": "sha512-rlhC65BALzQAVBEXYzr8bKqyhZIWLco+VWJ7Fs8D3bJCutyu6xX6d7XDAqQW5SmJCNrIdaKvl/B6Xzer/+z8DA==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0"
       }
     },
     "@pixi/filter-noise": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.0.0-rc.3.tgz",
-      "integrity": "sha512-FwJlzRbRcXu39pMOG92Ez/vaMcD2Zy2gnGEtkI51LuqQKIGIhrpQTI29Cxj64msS0G3Z3qfrQMlwh1ebqVjOkA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-5.2.0.tgz",
+      "integrity": "sha512-7IBHqjuze5VEMYOKPz/O7wR3mks7xvYKvWmUaLV7FopUtDUFjklrVBWY39nBOsXKXm0qLOkkdKcwsqyXZ7xOFg==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0"
       }
     },
     "@pixi/graphics": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.0.0-rc.3.tgz",
-      "integrity": "sha512-l6VsB748jtPw7emH87thHVuTtriTojDjqNO/Xou2/EY1UUOvrtclv+ryCkVtPqtgVnuiHnF+pU724q0WCPcCaw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-5.2.0.tgz",
+      "integrity": "sha512-sXmN8CEjzd56wVh18AOv1cxsB70tP1FWIukTPg8EaSlhiFqiclQDGkf6mKDajuVrj7JhBjvFenKmv3ADYnLkqA==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/interaction": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.0.0-rc.3.tgz",
-      "integrity": "sha512-IRBMHGKJwLIBnpPOpc4tpY7ua/vcF7olpf8XGHV1YKLJfOB6qwnwKzMGBQ+1CKIO324yDWk9s6tjJa5Qf+UGtw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/interaction/-/interaction-5.2.0.tgz",
+      "integrity": "sha512-YoFGrwkKgNFsusXObcfgKJtLxjqeOaek3tZxssnZZOUSzIJGQ4mLur2I36C2AAufB+GxBL38TiP1nkAVurMC6A==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/ticker": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/ticker": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/loaders": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.0.0-rc.3.tgz",
-      "integrity": "sha512-N8sBqbNikkkfOkQhZS0TYnS0fqKPlTcH6PXiCrAMquyd4IjoEJDYi4+UIZg6Ep5WkfQwk105KhGFDq1UhStSiA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/loaders/-/loaders-5.2.0.tgz",
+      "integrity": "sha512-lKd5RYGQ86NoQNFcu/IYLEkC/oa6XypDKewG9LDd7n9XKKeed0NRipg7HhcYVsliayYkszoQ/JdzidV/yxnHYw==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3",
-        "resource-loader": "^2.2.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/utils": "^5.2.0",
+        "resource-loader": "^3.0.1"
       }
     },
     "@pixi/math": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.0.0-rc.3.tgz",
-      "integrity": "sha512-of/s2hHwTAN4wOxnLYQDIJftWFJgZ+S24U5N/fP6RHs6OQyegOX3q7f9uvwa+c6ssFNzGpPIF0Df7U2yKZdPFQ=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-5.2.0.tgz",
+      "integrity": "sha512-Y21H/kMluJqZ/QWb8cdXuZlib6G26QfZtgc85KbSJmjpMVWw03g0OELqFqOhsMzNanXp3B4OL1ZsNXnp0lWROQ=="
     },
     "@pixi/mesh": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.0.0-rc.3.tgz",
-      "integrity": "sha512-8O2kPvJxaq5UcVxzytwVQHGOBuANw4715OoFTWEeSqrNnTXlPhCQmxxIvmpYJxPmOOd6xCRl3EZfwSDNOf+YKw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-5.2.0.tgz",
+      "integrity": "sha512-GTgxMlK3T2aWNk2CpWw6+zDXzOxDN15v4noVM6hqm691GQn6HXD68J14BHJhZxuP3PU9VD7/FARooMtAwaxVvg==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/mesh-extras": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.0.0-rc.3.tgz",
-      "integrity": "sha512-JdxvzbotuwTTWr9lSr8CVaIQ2swO5z58SH0siNKBLm5Qk29o/NuZWjlIrnquDla4gzeTjzyL/S2lMTXfJbRkcQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-5.2.0.tgz",
+      "integrity": "sha512-vmBcV3sRqHWZIfwd8GQEscqR8zzsgCLXdgE/tWOCGqgGbv0+mv25y/vRnRnL42YXZb/sPU1RrtgnDr7xHNVL2w==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/mesh": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/mesh": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/mixin-cache-as-bitmap": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.0.0-rc.3.tgz",
-      "integrity": "sha512-DxKHguDR6rvP6j9AXuJCgPqkfpeqpMtAwZUl1T9pp2TOblqWN/dG9GVTRigzclqef7sRus3I4t+OaDSG8riqog==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.2.0.tgz",
+      "integrity": "sha512-VaFxBiPFu5Ii3T/vwe+QozvQk/OMLApe0eTSXCzAZspijVCGVmnalTqDgY9GC6SvuLG967jRTdEwCAsc+w2uXA==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/mixin-get-child-by-name": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.0.0-rc.3.tgz",
-      "integrity": "sha512-f4xXXQbCPK9S7qoyvMfoVq8dp2WSFCfsE2rCJB5ePzVxizVok/Lfgg8Gb8CYQjXac58BPTXsyGnUr90eOKM87g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.2.0.tgz",
+      "integrity": "sha512-exL50cOrjOmJ02++Q56AamYkVKt7RqwdM0QQdfmJKRX9r8cG9u09IKW2/hWKGbyqNoP5gGORtZvXRCJG8JYH/A==",
       "requires": {
-        "@pixi/display": "^5.0.0-rc.3"
+        "@pixi/display": "^5.2.0"
       }
     },
     "@pixi/mixin-get-global-position": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.0.0-rc.3.tgz",
-      "integrity": "sha512-k79VBqC0s4L33sOCaM3EJ2iB7yowiUcPt05MJF6tEtDvbFbEGcGCJeqKyUV3yRR7W/88UV56zXd3GPiHreIV7A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.2.0.tgz",
+      "integrity": "sha512-9P2EeymV23OonCVOdgYu0ZFlUZoCXh0wK/6wf6wb0N4Nefcz0mPfafHV5gp/qwCgB9OJk4RLKna1BDfxXn4LCA==",
       "requires": {
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3"
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0"
       }
     },
     "@pixi/particles": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.0.0-rc.3.tgz",
-      "integrity": "sha512-oV+J0e5koU9N46J+ywuDy9FfhAhBQnj94u6SN7fS/9GjRZeyARwP1jQ1XBiPkngNcy8J7yqcrBCrWFv2sdTU2Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/particles/-/particles-5.2.0.tgz",
+      "integrity": "sha512-uB86M9hpiamclCOLMk6go0WJGXoiNfNzIIiC5OmUt61Fk3TSZiXbF//xWt/NB/unm3+WhycudSfR1IhLL1OdSw==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/polyfill": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.0.0-rc.3.tgz",
-      "integrity": "sha512-ZQ642fDy1VEGVSuN0WKS+LWRrOq6d6xbQQHuwIxkmHsNlTmlgSrEBGWAo+vg31YWPufeu79DMKv/CWonWr5ENg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/polyfill/-/polyfill-5.2.0.tgz",
+      "integrity": "sha512-xvwJ0vRVwf6fByvGTRzOsAv0N5GmopVI+pT5MV8Rk4AoqGQ8vWkhQQ8jy7PS4g0ak2DpwVrcTwUjxfrmjJCYTw==",
       "requires": {
         "es6-promise-polyfill": "^1.2.0",
-        "object-assign": "^4.0.1"
+        "object-assign": "^4.1.1"
       }
     },
     "@pixi/prepare": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.0.0-rc.3.tgz",
-      "integrity": "sha512-7DXYMNZm9QeiJrcCY4pwANyiIl9VWYWa2VBxPWj391Vi58wjwz0Sm80uTGDU9bys6jp/qSa6TJSobuzRl50n1Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-5.2.0.tgz",
+      "integrity": "sha512-WE/VUIJXFrYMXFmWom4BZYB78IHQNeRZfN1SDN4X11cOciFH8uDafDpkMsjND95HZAqw+yQPU2pKResQnWEtag==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/graphics": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/text": "^5.0.0-rc.3",
-        "@pixi/ticker": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/graphics": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/text": "^5.2.0",
+        "@pixi/ticker": "^5.2.0"
       }
     },
     "@pixi/runner": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.0.0-rc.3.tgz",
-      "integrity": "sha512-Fk727Q2Pn8whUclbDima0uQDnmrjMQJ0SIN+3N2E7qe38RWKt4cXHVqzmIKsLVGmTnONPvuyVmEKAy9476u/Fw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-5.2.0.tgz",
+      "integrity": "sha512-vy/SGG8QFHMrWAqebMQdhxl/l6WlIbHXMDNDCYBWwXKYjmKzycrrj2o/mK9cBko8WDuoTRZ0Pe3JZ3XDYEsn9w=="
     },
     "@pixi/settings": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.0.0-rc.3.tgz",
-      "integrity": "sha512-brvJZMaeFMW3OKRZrFVG/I6PkES8N8euo7dmEoA/buDGimxSFBC0F8mbMgDHvI9DJ/YZxiCnYfBA6W/A+PPliQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-5.2.0.tgz",
+      "integrity": "sha512-AIxcUbgM3mh2QxS+nxNcPsqnJEBg3x/UO9ZpNMRhed9UPM/5mQ8CGZUMLTzIxhjSS16Do4uK9vZikMjV8dXm/Q==",
       "requires": {
         "ismobilejs": "^0.5.1"
       }
     },
     "@pixi/sprite": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.0.0-rc.3.tgz",
-      "integrity": "sha512-HNMLTlkDtN4AdOB5Z5ySA7c7Gb3a/S+ZzFkg9uH8n6WX+YFDlIi1BTxcPSxVW7ku2S9AHDcumYVnWc8eX9NKsw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-5.2.0.tgz",
+      "integrity": "sha512-IW+S2Cs3MTcMSrsSA5fjk+xx3Q8eNrsT4hGVXy6JxViv3IknIqbyQwdSFGAyoowOwzhyg7xJExz7VDZRQBBLwg==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/sprite-animated": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.0.0-rc.3.tgz",
-      "integrity": "sha512-vnjOqMCM471kmh4q3G+3lD89F0J6RDqMzwXYfGQClaZ2pzngwl+TsjjSh65sQO3ZbeI1O5GGoDuB34WyM8BJHA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-5.2.0.tgz",
+      "integrity": "sha512-Liy5s3CKh2MuSJeVYX7w8mJ0//WMUPm/4ZHRJqRJApijjlXSxcnhHNxIMRLDb8iJNmqaoOi9qMUgK0AkGWuAtA==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/ticker": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/ticker": "^5.2.0"
       }
     },
     "@pixi/sprite-tiling": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.0.0-rc.3.tgz",
-      "integrity": "sha512-4BWhq7deH14GGlajmc5DU+0lOqI6JloaRid56pnAbvT/fjxgqmb2kp0sR0mIUkbZPC8ZLiu83GGLMkImx6EZEw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-5.2.0.tgz",
+      "integrity": "sha512-iLQ98PrUVKqVzTYJsu+ZMCIRsJ1wapg55tf+m/78KK+h0WmgY70CJbO/A68dTqYZMLR39XPCtUp9bXXzXNEEdQ==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/spritesheet": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.0.0-rc.3.tgz",
-      "integrity": "sha512-ABckpeUJW+KNkB5tQ1XSPQKLQu+PE017XQTqx5G2HnyL25mF16x2A8ww2s3VxKFnrJlAaq5hEzYYZ6t2+vjRXw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-5.2.0.tgz",
+      "integrity": "sha512-48WNC3tSUXbWA7ZswEacSiVh396FLe3KLhFpWk2oIJ+7MtMQ1IdtkGjAaXgv0zx0EvvnvEt1VoQVo2eALswR5Q==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/loaders": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/loaders": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/text": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.0.0-rc.3.tgz",
-      "integrity": "sha512-H1n7wsnNmRJ1ldbVFqi0XfD+8aWO7Po+YYiKaqy+x+mJIctCrEVEmBMMN0JEnnmPxW0J51CWLJGjVcPtNxg89Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text/-/text-5.2.0.tgz",
+      "integrity": "sha512-enEq/rJYXVobyGeTXCBTbRMlnKc7am+/WicymRt1bT7ia8L8A00xgOdEbfg6OeP2jLcyBVnopFhgHFe8jcp07Q==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/text-bitmap": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.0.0-rc.3.tgz",
-      "integrity": "sha512-Th/hJLsaGBIk43CeMIstUat+YT+LE8U0ZDddx+Bu0AE3OP0GOHhm2D0cMu0KPIRB1+Dpr31X32B4vGutc5M9Yg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-5.2.0.tgz",
+      "integrity": "sha512-RZD7GpQrKD+1B2wehnX0dI7ABB43JWNWoWXHl5wKfhjmPCxVmKEB9UfvOZd3sbnlxeL7BUA/gpYSxD6b6ZiA8g==",
       "requires": {
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/loaders": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/loaders": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "@pixi/ticker": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.0.0-rc.3.tgz",
-      "integrity": "sha512-FmWeMKyOb/TUEREpaeLVH3ZDs/NIEdIkB5+Yl3quXMFLhTBYxvecXkpRomEOsKGUOdQgoucsHlXk39sybsioHQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-5.2.0.tgz",
+      "integrity": "sha512-6xX786cX/RWmQKeRQ3bNvg8JjS0VLA2LQy1sOmUctx2AwdZysI04k2xdw9Krtpn1mkudgAcNrTEsgPeGEjIF9Q==",
       "requires": {
-        "@pixi/settings": "^5.0.0-rc.3"
+        "@pixi/settings": "^5.2.0"
       }
     },
     "@pixi/utils": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.0.0-rc.3.tgz",
-      "integrity": "sha512-vRrm4pfr6ROspMYKc95NAUjpFyyFLwvhlGu7z81LGbrGoR+BfWhO/BSh6RmKdz0HcFXIkZkBik10+zDHJmKybA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-5.2.0.tgz",
+      "integrity": "sha512-oMLRlvx+vWHPR06uiOvfOhtkG/LDBR3Syea9QZoIbCJE/GLYgJX8f0cVfrdI0kCgfGj4luc8/CWI745MKafUqQ==",
       "requires": {
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "earcut": "^2.1.3",
+        "@pixi/constants": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "earcut": "^2.1.5",
         "eventemitter3": "^3.1.0",
         "url": "^0.11.0"
       }
@@ -3148,9 +3148,9 @@
       }
     },
     "earcut": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.5.tgz",
-      "integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
+      "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -4491,9 +4491,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4650,9 +4650,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4909,15 +4909,24 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -4928,9 +4937,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -5485,9 +5494,9 @@
       "dev": true
     },
     "ismobilejs": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-0.5.1.tgz",
-      "integrity": "sha512-QX4STsOcBYqlTjVGuAdP1MiRVxtiUbRHOKH0v7Gn1EvfUVIQnrSdgCM4zB4VCZuIejnb2NUMUx0Bwd3EIG6yyA=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-0.5.2.tgz",
+      "integrity": "sha512-ta9UdV60xVZk/ZafFtSFslQaE76SvNkcs1r73d2PVR21zVzx9xuYv9tNe4MxA1NN7WoeCc2RjGot3Bz1eHDx3Q=="
     },
     "isobject": {
       "version": "3.0.1",
@@ -5751,9 +5760,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -6071,9 +6080,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.assign": {
@@ -6096,9 +6105,9 @@
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true,
       "optional": true
     },
@@ -6543,9 +6552,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -7516,44 +7525,44 @@
       }
     },
     "pixi.js": {
-      "version": "5.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.0.0-rc.3.tgz",
-      "integrity": "sha512-+B6ZMvJNEz/IoiC+BrwP9PsDonEAj4TOZw+yuZ/K8WQokcSm9uAp3PJ+6eFFWTjnkxsAcMP9tgldmDdTFoAF7w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-5.2.0.tgz",
+      "integrity": "sha512-q4gxbTU51nrh8qxbplU6EVx2dnb9SiI9OeQOrQmtmCTpysJXAK5p9M2c3v5JRIgK8ZCL74y5vrwHaaB1ZQoPKw==",
       "requires": {
-        "@pixi/accessibility": "^5.0.0-rc.3",
-        "@pixi/app": "^5.0.0-rc.3",
-        "@pixi/constants": "^5.0.0-rc.3",
-        "@pixi/core": "^5.0.0-rc.3",
-        "@pixi/display": "^5.0.0-rc.3",
-        "@pixi/extract": "^5.0.0-rc.3",
-        "@pixi/filter-alpha": "^5.0.0-rc.3",
-        "@pixi/filter-blur": "^5.0.0-rc.3",
-        "@pixi/filter-color-matrix": "^5.0.0-rc.3",
-        "@pixi/filter-displacement": "^5.0.0-rc.3",
-        "@pixi/filter-fxaa": "^5.0.0-rc.3",
-        "@pixi/filter-noise": "^5.0.0-rc.3",
-        "@pixi/graphics": "^5.0.0-rc.3",
-        "@pixi/interaction": "^5.0.0-rc.3",
-        "@pixi/loaders": "^5.0.0-rc.3",
-        "@pixi/math": "^5.0.0-rc.3",
-        "@pixi/mesh": "^5.0.0-rc.3",
-        "@pixi/mesh-extras": "^5.0.0-rc.3",
-        "@pixi/mixin-cache-as-bitmap": "^5.0.0-rc.3",
-        "@pixi/mixin-get-child-by-name": "^5.0.0-rc.3",
-        "@pixi/mixin-get-global-position": "^5.0.0-rc.3",
-        "@pixi/particles": "^5.0.0-rc.3",
-        "@pixi/polyfill": "^5.0.0-rc.3",
-        "@pixi/prepare": "^5.0.0-rc.3",
-        "@pixi/runner": "^5.0.0-rc.3",
-        "@pixi/settings": "^5.0.0-rc.3",
-        "@pixi/sprite": "^5.0.0-rc.3",
-        "@pixi/sprite-animated": "^5.0.0-rc.3",
-        "@pixi/sprite-tiling": "^5.0.0-rc.3",
-        "@pixi/spritesheet": "^5.0.0-rc.3",
-        "@pixi/text": "^5.0.0-rc.3",
-        "@pixi/text-bitmap": "^5.0.0-rc.3",
-        "@pixi/ticker": "^5.0.0-rc.3",
-        "@pixi/utils": "^5.0.0-rc.3"
+        "@pixi/accessibility": "^5.2.0",
+        "@pixi/app": "^5.2.0",
+        "@pixi/constants": "^5.2.0",
+        "@pixi/core": "^5.2.0",
+        "@pixi/display": "^5.2.0",
+        "@pixi/extract": "^5.2.0",
+        "@pixi/filter-alpha": "^5.2.0",
+        "@pixi/filter-blur": "^5.2.0",
+        "@pixi/filter-color-matrix": "^5.2.0",
+        "@pixi/filter-displacement": "^5.2.0",
+        "@pixi/filter-fxaa": "^5.2.0",
+        "@pixi/filter-noise": "^5.2.0",
+        "@pixi/graphics": "^5.2.0",
+        "@pixi/interaction": "^5.2.0",
+        "@pixi/loaders": "^5.2.0",
+        "@pixi/math": "^5.2.0",
+        "@pixi/mesh": "^5.2.0",
+        "@pixi/mesh-extras": "^5.2.0",
+        "@pixi/mixin-cache-as-bitmap": "^5.2.0",
+        "@pixi/mixin-get-child-by-name": "^5.2.0",
+        "@pixi/mixin-get-global-position": "^5.2.0",
+        "@pixi/particles": "^5.2.0",
+        "@pixi/polyfill": "^5.2.0",
+        "@pixi/prepare": "^5.2.0",
+        "@pixi/runner": "^5.2.0",
+        "@pixi/settings": "^5.2.0",
+        "@pixi/sprite": "^5.2.0",
+        "@pixi/sprite-animated": "^5.2.0",
+        "@pixi/sprite-tiling": "^5.2.0",
+        "@pixi/spritesheet": "^5.2.0",
+        "@pixi/text": "^5.2.0",
+        "@pixi/text-bitmap": "^5.2.0",
+        "@pixi/ticker": "^5.2.0",
+        "@pixi/utils": "^5.2.0"
       }
     },
     "pkg-dir": {
@@ -8268,11 +8277,11 @@
       "dev": true
     },
     "resource-loader": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-2.2.4.tgz",
-      "integrity": "sha512-MrY0bEJN26us3h4bzJUSP0n4tFEb79lCpYBavtLjSezWCcXZMgxhSgvC9LxueuqpcxG+qPjhwFu5SQAcUNacdA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-3.0.1.tgz",
+      "integrity": "sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==",
       "requires": {
-        "mini-signals": "^1.1.1",
+        "mini-signals": "^1.2.0",
         "parse-uri": "^1.0.0"
       }
     },
@@ -8583,9 +8592,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -9436,14 +9445,14 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "optional": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -9884,16 +9893,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.2.tgz",
-      "integrity": "sha512-imog1WIsi9Yb56yRt5TfYVxGmnWs3WSGU73ieSOlMVFwhJCA9W8fqFFMMj4kgDqiS/80LGdsYnWL7O9UcjEBlg==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -9910,38 +9926,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@flyover/box2d": "github:timothyr/box2d.ts#master",
     "core-js": "^2.5.4",
     "js-angusj-clipper": "^1.0.1",
-    "pixi.js": "^5.0.0-rc.3",
+    "pixi.js": "^5.2.0",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"


### PR DESCRIPTION
- Update PixiJS to v5
- Fix vulns with `npm audit fix`

Closes https://github.com/timothyr/slothroyale/issues/12